### PR TITLE
docs: simplify README setup instructions to use setup.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,31 +8,31 @@ Welcome to the **Basic Molecular Docking Workshop**! This guide will walk you th
 
 ## Table of Contents
 
-1. [What You’ll Learn](#what-youll-learn)
-2. [Prerequisites](#prerequisites)
-3. [Step 1: Install Anaconda](#step-1-install-anaconda)
-4. [Step 2: Open a Terminal](#step-2-open-a-terminal)
-5. [Step 3: Clone the Workshop Repository](#step-3-clone-the-workshop-repository)
-6. [Step 4: Create the Conda Environment](#step-4-create-the-conda-environment)
-7. [Step 5: Activate the Environment](#step-5-activate-the-environment)
-8. [Step 6: Verify Your Setup](#step-6-verify-your-setup)
-9. [Using the `pdbqt2pdb.sh` Script](#using-the-pdbqt2pdbsh-script)
-10. [Troubleshooting](#troubleshooting)
-11. [Acknowledgments](#acknowledgments)
+1. [What You’ll Learn](#what-youll-learn)  
+2. [Prerequisites](#prerequisites)  
+3. [Step 1: Install Anaconda](#step-1-install-anaconda)  
+4. [Step 2: Open a Terminal](#step-2-open-a-terminal)  
+5. [Step 3: Clone the Workshop Repository](#step-3-clone-the-workshop-repository)  
+6. [Step 4: Run the Setup Script](#step-4-run-the-setup-script)  
+7. [Using the `pdbqt2pdb.sh` Script](#using-the-pdbqt2pdbsh-script)  
+8. [Uninstallation](#uninstallation)  
+9. [Troubleshooting](#troubleshooting)  
+10. [Acknowledgments](#acknowledgments)  
 
 ---
 
 ## What You’ll Learn
 
-* How to install Anaconda, a tool that manages Python and packages for you.
-* What a terminal (or command prompt) is and how to open it.
-* How to create and manage a reproducible Python environment using Conda.
-* How to activate that environment and run scripts for molecular docking preparation.
+* How to install Anaconda, a tool that manages Python and packages for you.  
+* What a terminal (or command prompt) is and how to open it.  
+* How to clone the workshop repository.  
+* How to run the provided `setup.sh` to configure your Conda environment, install dependencies, and verify your setup.  
+* How to uninstall the workshop and remove all related files and environments.
 
 ## Prerequisites
 
-* A computer running **Windows**, **macOS**, or **Linux**.
-* Internet connection to download Anaconda and the workshop materials.
+* A computer running **Windows**, **macOS**, or **Linux**.  
+* Internet connection to download Anaconda and the workshop materials.  
 
 ---
 
@@ -40,13 +40,12 @@ Welcome to the **Basic Molecular Docking Workshop**! This guide will walk you th
 
 Anaconda is a free package manager that installs Python and many useful scientific packages.
 
-1. Open your web browser and go to the [Anaconda Downloads page](https://www.anaconda.com/products/distribution).
-2. Choose the installer for your operating system (Windows, macOS, or Linux).
+1. Open your web browser and go to the [Anaconda Downloads page](https://www.anaconda.com/products/distribution).  
+2. Choose the installer for your operating system (Windows, macOS, or Linux).  
 3. Download the installer and follow the on-screen instructions:
-
-   * **Windows**: Double-click the `.exe` file and click through the install wizard.
-   * **macOS**: Open the `.pkg` file and follow the prompts.
-   * **Linux**: Open a terminal and run `bash ~/Downloads/Anaconda3-*.sh`, then follow the prompts.
+   - **Windows**: Double-click the `.exe` file and click through the install wizard.  
+   - **macOS**: Open the `.pkg` file and follow the prompts.  
+   - **Linux**: Open a terminal and run `bash ~/Downloads/Anaconda3-*.sh`, then follow the prompts.
 
 Once installation is complete, you’ll have access to the `conda` command-line tool.
 
@@ -56,17 +55,14 @@ Once installation is complete, you’ll have access to the `conda` command-line 
 
 A **terminal** (also called a command prompt or shell) is a program where you type text commands to control your computer.
 
-* **Windows**:
-
-  1. Click the Start menu.
-  2. Search for **Anaconda Prompt** or **Command Prompt**.
-  3. Click to open it.
-* **macOS**:
-
-  1. Open **Finder** > **Applications** > **Utilities**.
-  2. Double-click **Terminal**.
-* **Linux**:
-
+- **Windows**:  
+  1. Click the Start menu.  
+  2. Search for **Anaconda Prompt** or **Command Prompt**.  
+  3. Click to open it.  
+- **macOS**:  
+  1. Open **Finder** > **Applications** > **Utilities**.  
+  2. Double-click **Terminal**.  
+- **Linux**:  
   1. Press `Ctrl + Alt + T` or search for **Terminal** in your applications menu.
 
 You should see a window with a prompt, such as `C:\Users\YourName>` on Windows or `your-macbook:~ yourname$` on macOS/Linux.
@@ -75,119 +71,40 @@ You should see a window with a prompt, such as `C:\Users\YourName>` on Windows o
 
 ## Step 3: Clone the Workshop Repository
 
-1. In your terminal, navigate to the folder where you want to keep the workshop files. For example:
-
+1. In your terminal, navigate to the folder where you want to keep the workshop files. For example:  
    ```bash
    cd ~/Documents
    ```
-
-2. Clone this repository from GitHub (you need to have [Git installed](https://git-scm.com/)—Anaconda includes Git by default):
-
+2. Clone this repository from GitHub (you need to have [Git installed](https://git-scm.com/)—Anaconda includes Git by default):  
    ```bash
    git clone https://github.com/yipy0005/Basic-Molecular-Docking-Workshop.git
    ```
-
-3. Change into the workshop directory:
-
+3. Change into the workshop directory:  
    ```bash
    cd Basic-Molecular-Docking-Workshop
    ```
 
 ---
 
-## Step 4: Create the Conda Environment
+## Step 4: Run the Setup Script
 
-The `environment.yml` file lists all the software and packages we need.
+We’ve provided a `setup.sh` that automates environment creation, dependency installation, and verification:
 
-1. In the terminal (make sure you’re inside the `Basic-Molecular-Docking-Workshop` folder), run:
-
+1. Make the script executable (only needed once):  
    ```bash
-   conda env create -f environment.yml
+   chmod +x setup.sh
    ```
+2. Run it:  
+   ```bash
+   ./setup.sh
+   ```
+3. Follow the on-screen output. When it finishes, you’ll have:
+   - A Conda environment named `molecular_docking_workshop`  
+   - All required packages (including Meeko, ProDy, AutoDock Vina, etc.)  
+   - Executables verified (`vina`, `reduce`, `python --version`)  
+   - The helper script `pdbqt2pdb.sh` made executable  
 
-2. Wait while Conda downloads and installs everything. This may take several minutes.
-
-You now have a new environment named `molecular_docking_workshop`.
-
----
-
-## Step 5: Activate the Environment
-
-Before using any workshop tools, you must "activate" the environment:
-
-* **All operating systems**:
-
-  ```bash
-  conda activate molecular_docking_workshop
-  ```
-
-After activation, your prompt will change to show the environment name, for example:
-
-```bash
-(molecular_docking_workshop) your-computer:Basic-Molecular-Docking-Workshop yourname$
-```
-
----
-
-## Step 5: Activate the Environment
-
-Before using any workshop tools, you must "activate" the environment:
-
-* **All operating systems**:
-
-  ```bash
-  conda activate molecular_docking_workshop
-  ```
-
-After activation, your prompt will change to show the environment name, for example:
-
-```bash
-(molecular_docking_workshop) your-computer:Basic-Molecular-Docking-Workshop yourname$
-```
-
-### Additional Setup: Install Meeko and ProDy
-
-Once the environment is active, install the **Meeko** package and **ProDy**:
-
-```bash
-# Clone the Meeko repository and navigate to the Meeko folder
-git clone https://github.com/forlilab/Meeko.git
-cd Meeko
-```
-
-```bash
-# Switch to the development branch
-git checkout develop
-```
-
-```bash
-# Install Meeko in editable mode
-pip install .
-```
-
-```bash
-# Install ProDy
-pip install prody
-```
-
-```bash
-# Return to the workshop root folder
-cd ..
-```
-
----
-
-## Step 6: Verify Your Setup
-
-With the environment active, check that key programs are available:
-
-```bash
-which vina      # Should print a path to the "vina" executable
-which reduce    # Should print a path to the "reduce" executable
-python --version  # Should print Python 3.10.x
-```
-
-If these commands return paths and versions without errors, you’re all set!
+Once `setup.sh` completes successfully, you’re ready to proceed to the tutorial.
 
 ---
 
@@ -195,32 +112,42 @@ If these commands return paths and versions without errors, you’re all set!
 
 We provide a script to convert `.pdbqt` files into individual `.pdb` files.
 
-1. Make the script executable (only needed once):
-
-   ```bash
-   chmod +x pdbqt2pdb.sh
-   ```
-
-2. Run the script on a `.pdbqt` file:
-
+1. (Already made executable by `setup.sh`—no action needed.)  
+2. Run the script on a `.pdbqt` file:  
    ```bash
    ./pdbqt2pdb.sh my_structure.pdbqt
    ```
-
-   * The script splits each `MODEL` into its own file and converts them to `.pdb` format.
-   * You’ll see output like:
-
+   - The script splits each `MODEL` into its own file and converts them to `.pdb` format.  
+   - You’ll see output like:
      ```
      → Converted to my_structure_model1.pdb and removed my_structure_model1.pdbqt
      ```
 
 ---
 
+## Uninstallation
+
+If you ever want to remove the workshop and its environment entirely, use the provided `uninstall.sh`:
+
+1. Make the script executable (if you haven’t already):  
+   ```bash
+   chmod +x uninstall.sh
+   ```
+2. Run it:  
+   ```bash
+   ./uninstall.sh
+   ```
+3. This will:
+   - Deactivate and remove the `molecular_docking_workshop` Conda environment  
+   - Delete the entire `Basic-Molecular-Docking-Workshop` directory  
+
+---
+
 ## Troubleshooting
 
-* **"Command not found" errors**: Make sure you have activated the environment with `conda activate molecular_docking_workshop`.
-* **Permission denied** when running the script: Ensure you ran `chmod +x pdbqt2pdb.sh`.
-* If you get stuck at any step, feel free to ask for help or check online resources for Conda and Git.
+* **"Command not found" errors**: Ensure you used `./setup.sh` and that it finished without errors.  
+* **Permission denied** when running scripts: Verify `chmod +x setup.sh uninstall.sh pdbqt2pdb.sh` has been applied.  
+* If you get stuck, feel free to ask for help or check online resources for Conda, Git, and the workshop repo.
 
 ---
 
@@ -228,8 +155,8 @@ We provide a script to convert `.pdbqt` files into individual `.pdb` files.
 
 This workshop uses open-source tools including:
 
-* [RDKit](https://www.rdkit.org/)
-* [AutoDock Vina](http://vina.scripps.edu/)
+* [RDKit](https://www.rdkit.org/)  
+* [AutoDock Vina](http://vina.scripps.edu/)  
 * [Biopython, Gemmi, SciPy](https://www.scipy.org/)
 
 Enjoy learning molecular docking!

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve work dir to absolute path (default ~/Documents)
+WORK_DIR="."
+#WORK_DIR="${1:-$HOME/Documents}"
+WORK_DIR="$(realpath "$WORK_DIR")"
+REPO_URL="https://github.com/yipy0005/Basic-Molecular-Docking-Workshop.git"
+#REPO_DIR="Basic-Molecular-Docking-Workshop"
+#REPO_PATH="$WORK_DIR/$REPO_DIR"
+ENV_NAME="molecular_docking_workshop"
+MEEKO_URL="https://github.com/forlilab/Meeko.git"
+
+echo
+echo "=== Basic Molecular Docking Workshop Setup ==="
+echo
+
+# 1. Check for conda
+if ! command -v conda &>/dev/null; then
+  echo "Error: 'conda' not found. Please install Anaconda first:"
+  echo "  https://www.anaconda.com/products/distribution"
+  exit 1
+fi
+eval "$(conda shell.bash hook)"
+
+# 2. Clone or update workshop repo
+#$echo "-> Cloning/updating workshop repository in $WORK_DIR"
+#$cd "$WORK_DIR"
+#$if [ -d "$REPO_PATH/.git" ]; then
+#$  git -C "$REPO_PATH" pull
+#$else
+#$  git clone "$REPO_URL"
+#$fi
+
+# 3. Create the conda env if needed
+echo
+echo "-> Ensuring conda env '$ENV_NAME' exists"
+if conda env list | awk '{print $1}' | grep -qx "$ENV_NAME"; then
+  echo "   Environment already exists."
+else
+  conda env create -f "$WORK_DIR/environment.yml"
+fi
+
+# 4. Activate it
+echo
+echo "-> Activating '$ENV_NAME'"
+conda activate "$ENV_NAME"
+
+# 5. Install Meeko & ProDy
+echo
+echo "-> Installing Meeko (develop) & ProDy"
+# if Meeko isn't already cloned, git clone creates the folder
+if [ ! -d "$WORK_DIR/Meeko/.git" ]; then
+  git clone "$MEEKO_URL" "$WORK_DIR/Meeko"
+fi
+cd "$WORK_DIR/Meeko"
+git fetch --all
+git checkout develop
+pip install -e .
+pip install prody
+
+# 6. Verify tools
+echo
+echo "-> Verifying your setup"
+echo -n "   vina:   " && which vina || echo "NOT FOUND"
+echo -n "   reduce: " && which reduce || echo "NOT FOUND"
+echo -n "   python: " && python --version
+
+# 7. Make pdbqt2pdb.sh executable
+echo
+echo "-> Making pdbqt2pdb.sh executable"
+chmod +x "$WORK_DIR/pdbqt2pdb.sh"
+
+echo
+echo "✅  Setup complete!"
+echo "    cd $WORK_DIR"
+echo "    conda activate $ENV_NAME"
+echo "    bash TUTORIAL.md"
+echo

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_NAME="molecular_docking_workshop"
+REPO_DIR="Basic-Molecular-Docking-Workshop"
+
+# Where this script lives (parent of the repo)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_PATH="$SCRIPT_DIR/$REPO_DIR"
+
+echo
+echo "=== Uninstalling Molecular Docking Workshop ==="
+echo
+
+# 1. Remove conda environment if present and existing
+eval "$(conda shell.bash hook)" 2>/dev/null || true
+if command -v conda &>/dev/null; then
+  # Check if the environment exists
+  if conda env list | awk '{print $1}' | grep -qx "$ENV_NAME"; then
+    if [ "${CONDA_DEFAULT_ENV:-}" = "$ENV_NAME" ]; then
+      echo "-> Deactivating environment '$ENV_NAME'..."
+      conda deactivate
+    fi
+    echo "-> Removing conda environment '$ENV_NAME'..."
+    conda env remove --name "$ENV_NAME" -y
+  else
+    echo "-> Conda environment '$ENV_NAME' not found. Skipping environment removal."
+  fi
+else
+  echo "Warning: 'conda' not found. Skipping environment removal."
+fi
+
+# 2. If inside the repo, cd out automatically
+CURRENT_DIR="$(pwd)"
+if [[ "$CURRENT_DIR" == "$REPO_PATH" ]] || [[ "$CURRENT_DIR" == "$REPO_PATH/"* ]]; then
+  echo "-> You are inside '$REPO_PATH'. Moving up to home directory to proceed..."
+  cd ~
+fi
+
+# 3. Remove the repository directory
+if [ -d "$REPO_PATH" ]; then
+  echo "-> Deleting directory '$REPO_PATH'..."
+  rm -rf "$REPO_PATH"
+else
+  echo "-> Directory '$REPO_PATH' not found. Nothing to remove."
+fi
+
+echo
+echo "✅ Uninstallation complete."
+echo


### PR DESCRIPTION
- Replace steps 4, 5, and 6 with single setup script execution
- Update table of contents to reflect simplified workflow
- Streamline installation process for better user experience

## Summary by Sourcery

Introduce setup and uninstallation scripts to automate environment setup and teardown, and simplify README instructions accordingly.

New Features:
- Add setup.sh to automate repository cloning, Conda environment creation, dependency installation, and tool verification
- Add uninstall.sh to remove the Conda environment and delete the workshop directory

Enhancements:
- Replace manual multi-step setup in README with a single setup script execution
- Streamline README installation workflow and update the table of contents to reflect the new steps

Documentation:
- Update README.md to consolidate steps 4–6 into running setup.sh and add an uninstallation section